### PR TITLE
fix: don't Require all fields filled

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -39,18 +39,6 @@ document.getElementById("saveButton").addEventListener("click", () => {
 
   const selectedAI = document.getElementById("toggle").value;
 
-  if (
-    !gptKey ||
-    !geminiKey ||
-    !gptEndpoint ||
-    !geminiEndpoint ||
-    !grokKey ||
-    !grokEndpoint
-  ) {
-    alert("Please fill in all fields.");
-    return;
-  }
-
   chrome.storage.local.get("DATA", ({ DATA }) => {
     const newData = {
       gptKey: gptKey !== DEFAULT_KEY ? gptKey : DATA.gptKey,


### PR DESCRIPTION
Previously, all key fields were required to save. Now all validations have been removed. Before using, one needs to either fill in the key fields or select any available Local LLMs.